### PR TITLE
Improve PatchCreator interface, add basic 2D training support

### DIFF
--- a/elektronn3/data/cnndata.py
+++ b/elektronn3/data/cnndata.py
@@ -4,7 +4,7 @@
 # Max Planck Institute of Neurobiology, Munich, Germany
 # Authors: Martin Drawitsch, Philipp Schubert
 
-__all__ = ['PatchCreator']
+__all__ = ['PatchCreator', 'SimpleNeuroData2d']
 
 import logging
 import os

--- a/elektronn3/data/cnndata.py
+++ b/elektronn3/data/cnndata.py
@@ -450,8 +450,8 @@ class PatchCreator(data.Dataset):
         if self.normalize:
             inp_np = ((inp_np - self.mean) / self.std).astype(np.float32)
 
-        inp = torch.from_numpy(inp_np).to(self.device)
-        target = torch.from_numpy(target_np).to(self.device)
+        inp = torch.from_numpy(inp_np)
+        target = torch.from_numpy(target_np)
 
         # See comments at the end of PatchCreator.__getitem__()
         # Note that here it's the dimension index 1 that we're squeezing,
@@ -462,15 +462,6 @@ class PatchCreator(data.Dataset):
 
         return inp, target
 
-    # In this implementation the preview batch is always kept in GPU memory.
-    # This means much better inference speed when using it, but this may be
-    # a bad decision if GPU memory is limited.
-    # --> TODO: Document this concern and decide how to deal with it.
-    #           (E.g. suggest a smaller preview shape if catching OOM,
-    #            or keep the batch in main memory ("cpu") and only move it
-    #            to GPU when needed, freeing up GPU memory afterwards
-    #            -> first evaluate cost of moving?...)
-    #
     # TODO: Make targets optional so we can have larger previews without ground truth targets?
 
     @property

--- a/elektronn3/data/cnndata.py
+++ b/elektronn3/data/cnndata.py
@@ -33,7 +33,7 @@ class PatchCreator(data.Dataset):
     It implements the PyTorch ``Dataset`` interface and is meant to be used
     with a PyTorch ``DataLoader`` (or the modified
     :py:class:`elektronn3.training.trainer.train_utils.DelayedDataLoader``, if it is
-    used with :py:class:`elektronn3.training.trainer.StoppableTrainer``).
+    used with :py:class:`elektronn3.training.trainer.Trainer``).
 
     The main idea of this class is to automate input and target patch creation
     for training convnets for semantic image segmentation. Patches are sliced
@@ -130,7 +130,7 @@ class PatchCreator(data.Dataset):
             one "training phase", so after each ``epoch_size`` batches,
             validation/logging/plotting are performed by the training loop
             that uses this data set (e.g.
-            ``elektronn3.training.trainer.StoppableTrainer``).
+            ``elektronn3.training.trainer.Trainer``).
         eager_init: If ``False``, some parts of the class initialization
             are lazily performed only when they are needed.
             It's not recommended to change this option.

--- a/elektronn3/training/trainer.py
+++ b/elektronn3/training/trainer.py
@@ -279,6 +279,8 @@ class Trainer:
                         else:
                             sched.step()
                     self.step += 1
+                    if self.step >= max_steps:
+                        break
                 stats['tr_err'] = 100. * incorrect / numel
                 stats['tr_loss'] /= len(self.train_loader)
                 mean_target = target_sum / numel

--- a/elektronn3/training/trainer.py
+++ b/elektronn3/training/trainer.py
@@ -200,7 +200,7 @@ class StoppableTrainer:
             self.tb = TensorBoardLogger(log_dir=tb_path, always_flush=False)
 
         self.train_loader = DelayedDataLoader(
-            self.train_dataset, batch_size=self.batchsize, shuffle=False,
+            self.train_dataset, batch_size=self.batchsize, shuffle=True,
             num_workers=self.num_workers, pin_memory=True,
             timeout=30  # timeout arg requires https://github.com/pytorch/pytorch/commit/1661370ac5f88ef11fedbeac8d0398e8369fc1f3
         )
@@ -467,6 +467,7 @@ class StoppableTrainer:
             self.tb.log_image(f'{group}/target', target, step=0)
             self._first_plot = False
 
+    # TODO: There seems to be an issue with inp-target mismatches when batch_size > 1
     def tb_log_sample_images(
             self,
             images: Dict[str, torch.Tensor],

--- a/elektronn3/training/trainer.py
+++ b/elektronn3/training/trainer.py
@@ -433,7 +433,10 @@ class StoppableTrainer:
             z_plane: Optional[int] = None,
             group: str = 'preview_batch'
     ) -> None:
-        """Preview from constant region of preview batch data"""
+        """ Preview from constant region of preview batch data.
+
+        This only works for datasets that have a ``preview_batch`` attribute.
+        """
         inp_batch = self.valid_dataset.preview_batch[0].to(self.device)
         _, out_batch = preview_inference(self.model, inp_batch=inp_batch)
 

--- a/elektronn3/training/trainer.py
+++ b/elektronn3/training/trainer.py
@@ -40,7 +40,7 @@ class NaNException(RuntimeError):
     pass
 
 
-class StoppableTrainer:
+class Trainer:
     """ Training loop abstraction with IPython and tensorboard integration.
 
     Hitting Ctrl-C anytime during the training will drop you to the IPython

--- a/examples/random_blurring_augmentation_example.py
+++ b/examples/random_blurring_augmentation_example.py
@@ -6,17 +6,12 @@
 # Max Planck Institute of Neurobiology, Munich, Germany
 # Authors: Martin Drawitsch, Philipp Schubert
 
-raise NotImplementedError('Currently broken due to data refactoring, will fix after the new dataset interface is finished / moving less quickly.')
-
 import argparse
-import datetime
 import os
 
 import torch
 from torch import nn
 from torch import optim
-from elektronn3.data.random_blurring import ScalarScheduler
-
 
 parser = argparse.ArgumentParser(description='Train a network.')
 parser.add_argument('--disable-cuda', action='store_true', help='Disable CUDA')
@@ -40,14 +35,26 @@ import elektronn3
 elektronn3.select_mpl_backend('Agg')
 
 from elektronn3.data.cnndata import PatchCreator
+from elektronn3.data.random_blurring import ScalarScheduler
 from elektronn3.training.trainer import StoppableTrainer
 from elektronn3.models.unet import UNet
 
 
+torch.manual_seed(0)
+
+
 # USER PATHS
-data_path = os.path.expanduser('~/neuro_data_cdhw/')
 save_root = os.path.expanduser('~/e3training/')
 os.makedirs(save_root, exist_ok=True)
+data_root = os.path.expanduser('~/neuro_data_cdhw/')
+input_h5data = [
+    (os.path.join(data_root, f'raw_{i}.h5'), 'raw')
+    for i in range(3)
+]
+target_h5data = [
+    (os.path.join(data_root, f'barrier_int16_{i}.h5'), 'lab')
+    for i in range(3)
+]
 
 max_steps = 500000
 lr = 0.0004
@@ -55,6 +62,7 @@ lr_stepsize = 1000
 lr_dec = 0.995
 batch_size = 1
 
+# Initialize neural network model
 model = UNet(
     n_blocks=3,
     start_filts=32,
@@ -62,12 +70,8 @@ model = UNet(
     activation='relu',
     batch_norm=True
 ).to(device)
-# Note that DataParallel only makes sense with batch_size >= 2
-# model = nn.parallel.DataParallel(model, device_ids=[0, 1])
-torch.manual_seed(0)
-if device.type == 'cuda':
-    torch.cuda.manual_seed(0)
 
+# Configure random local blurring
 threshold = ScalarScheduler(
     value=0.1,
     max_value=0.5,
@@ -85,31 +89,43 @@ random_blurring_config = {
     "num_steps_save": 1000
 }
 
-data_init_kwargs = {
-    'input_path': data_path,
-    'target_path': data_path,
-    'input_h5data': [('raw_%i.h5' % i, 'raw') for i in range(3)],
-    'target_h5data': [('barrier_int16_%i.h5' %i, 'lab') for i in range(3)],
+# Specify data set
+common_data_kwargs = {  # Common options for training and valid sets.
     'mean': 155.291411,
     'std': 41.812504,
     'aniso_factor': 2,
-    'source': 'train',
     'patch_shape': (48, 96, 96),
-    'preview_shape': (64, 144, 144),
-    'valid_cube_indices': [2],
-    'grey_augment_channels': [],
-    'random_blurring_config': random_blurring_config,
-    'epoch_size': args.epoch_size,
-    'warp': 0.5,
-    'class_weights': True,
-    'warp_kwargs': {
-        'sample_aniso': True,
-        'perspective': True
-    },
-    'squeeze_target': True,  # Workaround for neuro_data_cdhw
+    'squeeze_target': True,  # Workaround for neuro_data_cdhw,
+    'device': device,
 }
-dataset = PatchCreator(**data_init_kwargs, device=device)
+train_dataset = PatchCreator(
+    input_h5data=input_h5data[:2],
+    target_h5data=target_h5data[:2],
+    train=True,
+    epoch_size=args.epoch_size,
+    class_weights=True,
+    warp=0.5,
+    warp_kwargs={
+        'sample_aniso': True,
+        'perspective': True,
+    },
+    random_blurring_config=random_blurring_config,
+    **common_data_kwargs
+)
+valid_dataset = PatchCreator(
+    input_h5data=[input_h5data[2]],
+    target_h5data=[target_h5data[2]],
+    train=False,
+    epoch_size=10,  # How many samples to use for each validation run
+    preview_shape=(64, 144, 144),
+    warp=0,
+    warp_kwargs={
+        'sample_aniso': True,
+    },
+    **common_data_kwargs
+)
 
+# Set up optimization
 optimizer = optim.Adam(
     model.parameters(),
     weight_decay=0.5e-4,
@@ -119,19 +135,21 @@ optimizer = optim.Adam(
 lr_sched = optim.lr_scheduler.StepLR(optimizer, lr_stepsize, lr_dec)
 # lr_sched = optim.lr_scheduler.ReduceLROnPlateau(optimizer, patience=10, factor=0.5)
 
-criterion = nn.CrossEntropyLoss(weight=dataset.class_weights).to(device)
+criterion = nn.CrossEntropyLoss(weight=train_dataset.class_weights).to(device)
 # TODO: Dice loss? (used in original V-Net) https://github.com/mattmacy/torchbiomed/blob/661b3e4411f7e57f4c5cbb56d02998d2d8bddfdb/torchbiomed/loss.py
 
-st = StoppableTrainer(
+# Create and run trainer
+trainer = StoppableTrainer(
     model=model,
     criterion=criterion,
     optimizer=optimizer,
     device=device,
-    train_dataset=dataset,
+    train_dataset=train_dataset,
+    valid_dataset=valid_dataset,
     batchsize=batch_size,
     num_workers=2,
     save_root=save_root,
     exp_name=args.exp_name,
     schedulers={"lr": lr_sched}
 )
-st.train(max_steps)
+trainer.train(max_steps)

--- a/examples/random_blurring_augmentation_example.py
+++ b/examples/random_blurring_augmentation_example.py
@@ -36,7 +36,7 @@ elektronn3.select_mpl_backend('Agg')
 
 from elektronn3.data.cnndata import PatchCreator
 from elektronn3.data.random_blurring import ScalarScheduler
-from elektronn3.training.trainer import StoppableTrainer
+from elektronn3.training.trainer import Trainer
 from elektronn3.models.unet import UNet
 
 
@@ -139,7 +139,7 @@ criterion = nn.CrossEntropyLoss(weight=train_dataset.class_weights).to(device)
 # TODO: Dice loss? (used in original V-Net) https://github.com/mattmacy/torchbiomed/blob/661b3e4411f7e57f4c5cbb56d02998d2d8bddfdb/torchbiomed/loss.py
 
 # Create and run trainer
-trainer = StoppableTrainer(
+trainer = Trainer(
     model=model,
     criterion=criterion,
     optimizer=optimizer,

--- a/examples/random_blurring_augmentation_example.py
+++ b/examples/random_blurring_augmentation_example.py
@@ -6,6 +6,8 @@
 # Max Planck Institute of Neurobiology, Munich, Germany
 # Authors: Martin Drawitsch, Philipp Schubert
 
+raise NotImplementedError('Currently broken due to data refactoring, will fix after the new dataset interface is finished / moving less quickly.')
+
 import argparse
 import datetime
 import os
@@ -125,7 +127,7 @@ st = StoppableTrainer(
     criterion=criterion,
     optimizer=optimizer,
     device=device,
-    dataset=dataset,
+    train_dataset=dataset,
     batchsize=batch_size,
     num_workers=2,
     save_root=save_root,

--- a/examples/random_blurring_augmentation_example.py
+++ b/examples/random_blurring_augmentation_example.py
@@ -15,11 +15,15 @@ from torch import optim
 
 parser = argparse.ArgumentParser(description='Train a network.')
 parser.add_argument('--disable-cuda', action='store_true', help='Disable CUDA')
-parser.add_argument('--exp-name', default=None, help='Manually set experiment name')
+parser.add_argument('-n', '--exp-name', default=None, help='Manually set experiment name')
 parser.add_argument(
-    '--epoch-size', type=int, default=100,
+    '-s', '--epoch-size', type=int, default=100,
     help='How many training samples to process between '
          'validation/preview/extended-stat calculation phases.'
+)
+parser.add_argument(
+    '-m', '--max-steps', type=int, default=500000,
+    help='Maximum number of training steps to perform.'
 )
 args = parser.parse_args()
 
@@ -56,7 +60,7 @@ target_h5data = [
     for i in range(3)
 ]
 
-max_steps = 500000
+max_steps = args.max_steps
 lr = 0.0004
 lr_stepsize = 1000
 lr_dec = 0.995

--- a/examples/simple2d.py
+++ b/examples/simple2d.py
@@ -23,7 +23,11 @@ from torch import optim
 
 parser = argparse.ArgumentParser(description='Train a network.')
 parser.add_argument('--disable-cuda', action='store_true', help='Disable CUDA')
-parser.add_argument('--exp-name', default=None, help='Manually set experiment name')
+parser.add_argument('-n', '--exp-name', default=None, help='Manually set experiment name')
+parser.add_argument(
+    '-m', '--max-steps', type=int, default=500000,
+    help='Maximum number of training steps to perform.'
+)
 args = parser.parse_args()
 
 if not args.disable_cuda and torch.cuda.is_available():
@@ -46,7 +50,7 @@ torch.manual_seed(0)
 # USER PATHS
 save_root = os.path.expanduser('~/e3training/')
 
-max_steps = 5000
+max_steps = args.max_steps
 lr = 0.0004
 lr_stepsize = 1000
 lr_dec = 0.995

--- a/examples/simple2d.py
+++ b/examples/simple2d.py
@@ -37,7 +37,7 @@ print(f'Running on device: {device}')
 import elektronn3
 elektronn3.select_mpl_backend('Agg')
 
-from elektronn3.training.trainer import StoppableTrainer
+from elektronn3.training.trainer import Trainer
 from elektronn3.data.cnndata import SimpleNeuroData2d
 
 torch.manual_seed(0)
@@ -76,7 +76,7 @@ lr_sched = optim.lr_scheduler.StepLR(optimizer, lr_stepsize, lr_dec)
 criterion = nn.CrossEntropyLoss().to(device)
 
 # Create and run trainer
-trainer = StoppableTrainer(
+trainer = Trainer(
     model=model,
     criterion=criterion,
     optimizer=optimizer,

--- a/examples/simple2d.py
+++ b/examples/simple2d.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+
+# ELEKTRONN3 - Neural Network Toolkit
+#
+# Copyright (c) 2017 - now
+# Max Planck Institute of Neurobiology, Munich, Germany
+# Authors: Martin Drawitsch, Philipp Schubert
+
+"""
+Demo of a 2D semantic segmentation workflow.
+
+It doesn't really learn anything useful, since both model and dataset
+are far too small. It just serves as a quick demo for how 2D stuff can
+be implemented.
+"""
+
+import argparse
+import os
+
+import torch
+from torch import nn
+from torch import optim
+
+parser = argparse.ArgumentParser(description='Train a network.')
+parser.add_argument('--disable-cuda', action='store_true', help='Disable CUDA')
+parser.add_argument('--exp-name', default=None, help='Manually set experiment name')
+args = parser.parse_args()
+
+if not args.disable_cuda and torch.cuda.is_available():
+    device = torch.device('cuda')
+else:
+    device = torch.device('cpu')
+
+print(f'Running on device: {device}')
+
+# Don't move this stuff, it needs to be run this early to work
+import elektronn3
+elektronn3.select_mpl_backend('Agg')
+
+from elektronn3.training.trainer import StoppableTrainer
+from elektronn3.data.cnndata import SimpleNeuroData2d
+
+torch.manual_seed(0)
+
+
+# USER PATHS
+save_root = os.path.expanduser('~/e3training/')
+
+max_steps = 5000
+lr = 0.0004
+lr_stepsize = 1000
+lr_dec = 0.995
+batch_size = 1
+
+# Initialize neural network model
+model = nn.Sequential(
+    nn.Conv2d(1, 32, 3, padding=1), nn.ReLU(),
+    nn.Conv2d(32, 32, 3, padding=1), nn.ReLU(),
+    nn.Conv2d(32, 32, 3, padding=1), nn.ReLU(),
+    nn.Conv2d(32, 2, 1)
+).to(device)
+
+# Specify data set
+train_dataset = SimpleNeuroData2d(train=True)
+valid_dataset = SimpleNeuroData2d(train=False)
+
+# Set up optimization
+optimizer = optim.Adam(
+    model.parameters(),
+    weight_decay=0.5e-4,
+    lr=lr,
+    amsgrad=True
+)
+lr_sched = optim.lr_scheduler.StepLR(optimizer, lr_stepsize, lr_dec)
+
+criterion = nn.CrossEntropyLoss().to(device)
+
+# Create and run trainer
+trainer = StoppableTrainer(
+    model=model,
+    criterion=criterion,
+    optimizer=optimizer,
+    device=device,
+    train_dataset=train_dataset,
+    valid_dataset=valid_dataset,
+    batchsize=batch_size,
+    num_workers=2,
+    save_root=save_root,
+    exp_name=args.exp_name,
+    schedulers={"lr": lr_sched}
+)
+trainer.train(max_steps)

--- a/examples/train_unet_neurodata.py
+++ b/examples/train_unet_neurodata.py
@@ -35,7 +35,7 @@ import elektronn3
 elektronn3.select_mpl_backend('Agg')
 
 from elektronn3.data.cnndata import PatchCreator
-from elektronn3.training.trainer import StoppableTrainer
+from elektronn3.training.trainer import Trainer
 from elektronn3.models.unet import UNet
 
 torch.manual_seed(0)
@@ -118,7 +118,7 @@ criterion = nn.CrossEntropyLoss(weight=train_dataset.class_weights).to(device)
 # TODO: Dice loss? (used in original V-Net) https://github.com/mattmacy/torchbiomed/blob/661b3e4411f7e57f4c5cbb56d02998d2d8bddfdb/torchbiomed/loss.py
 
 # Create and run trainer
-trainer = StoppableTrainer(
+trainer = Trainer(
     model=model,
     criterion=criterion,
     optimizer=optimizer,

--- a/examples/train_unet_neurodata.py
+++ b/examples/train_unet_neurodata.py
@@ -80,7 +80,7 @@ train_kwargs = {
     **shared_kwargs,
     'input_h5data': [('raw_%i.h5' % i, 'raw') for i in range(2)],
     'target_h5data': [('barrier_int16_%i.h5' % i, 'lab') for i in range(2)],
-    'source': 'train',
+    'train': True,
     'epoch_size': args.epoch_size,
     'class_weights': True,
     'warp': 0.5,
@@ -93,7 +93,7 @@ valid_kwargs = {
     **shared_kwargs,
     'input_h5data': [('raw_2.h5', 'raw')],
     'target_h5data': [('barrier_int16_2.h5', 'lab')],
-    'source': 'valid',
+    'train': False,
     'epoch_size': 10,  # How many samples to use for each validation run
     'preview_shape': (64, 144, 144),
     'warp': 0,

--- a/examples/train_unet_neurodata.py
+++ b/examples/train_unet_neurodata.py
@@ -69,22 +69,20 @@ if device.type == 'cuda':
 shared_kwargs = {
     'input_path': data_path,
     'target_path': data_path,
-    'input_h5data': [('raw_%i.h5' % i, 'raw') for i in range(3)],
-    'target_h5data': [('barrier_int16_%i.h5' %i, 'lab') for i in range(3)],
     'mean': 155.291411,
     'std': 41.812504,
     'aniso_factor': 2,
     'patch_shape': (48, 96, 96),
-    'valid_cube_indices': [2],
-    'grey_augment_channels': [],
     'epoch_size': args.epoch_size,
-    'class_weights': True,
     'squeeze_target': True,  # Workaround for neuro_data_cdhw
 }
 train_kwargs = {
     **shared_kwargs,
+    'input_h5data': [('raw_%i.h5' % i, 'raw') for i in range(2)],
+    'target_h5data': [('barrier_int16_%i.h5' % i, 'lab') for i in range(2)],
     'source': 'train',
     'epoch_size': args.epoch_size,
+    'class_weights': True,
     'warp': 0.5,
     'warp_kwargs': {
         'sample_aniso': True,
@@ -93,6 +91,8 @@ train_kwargs = {
 }
 valid_kwargs = {
     **shared_kwargs,
+    'input_h5data': [('raw_2.h5', 'raw')],
+    'target_h5data': [('barrier_int16_2.h5', 'lab')],
     'source': 'valid',
     'epoch_size': 10,  # How many samples to use for each validation run
     'preview_shape': (64, 144, 144),

--- a/examples/train_unet_neurodata.py
+++ b/examples/train_unet_neurodata.py
@@ -41,9 +41,17 @@ from elektronn3.models.unet import UNet
 
 
 # USER PATHS
-data_path = os.path.expanduser('~/neuro_data_cdhw/')
 save_root = os.path.expanduser('~/e3training/')
 os.makedirs(save_root, exist_ok=True)
+data_root = os.path.expanduser('~/neuro_data_cdhw/')
+input_h5data = [
+    (os.path.join(data_root, f'raw_{i}.h5'), 'raw')
+    for i in range(3)
+]
+target_h5data = [
+    (os.path.join(data_root, f'barrier_int16_{i}.h5'), 'lab')
+    for i in range(3)
+]
 
 max_steps = 500000
 lr = 0.0004
@@ -67,8 +75,6 @@ if device.type == 'cuda':
 
 # TODO: This dictionary stuff is getting out of hand. Simplify it.
 shared_kwargs = {
-    'input_path': data_path,
-    'target_path': data_path,
     'mean': 155.291411,
     'std': 41.812504,
     'aniso_factor': 2,
@@ -78,8 +84,8 @@ shared_kwargs = {
 }
 train_kwargs = {
     **shared_kwargs,
-    'input_h5data': [('raw_%i.h5' % i, 'raw') for i in range(2)],
-    'target_h5data': [('barrier_int16_%i.h5' % i, 'lab') for i in range(2)],
+    'input_h5data': input_h5data[:2],
+    'target_h5data': target_h5data[:2],
     'train': True,
     'epoch_size': args.epoch_size,
     'class_weights': True,
@@ -91,8 +97,8 @@ train_kwargs = {
 }
 valid_kwargs = {
     **shared_kwargs,
-    'input_h5data': [('raw_2.h5', 'raw')],
-    'target_h5data': [('barrier_int16_2.h5', 'lab')],
+    'input_h5data': [input_h5data[2]],
+    'target_h5data': [target_h5data[2]],
     'train': False,
     'epoch_size': 10,  # How many samples to use for each validation run
     'preview_shape': (64, 144, 144),

--- a/examples/train_unet_neurodata.py
+++ b/examples/train_unet_neurodata.py
@@ -15,11 +15,15 @@ from torch import optim
 
 parser = argparse.ArgumentParser(description='Train a network.')
 parser.add_argument('--disable-cuda', action='store_true', help='Disable CUDA')
-parser.add_argument('--exp-name', default=None, help='Manually set experiment name')
+parser.add_argument('-n', '--exp-name', default=None, help='Manually set experiment name')
 parser.add_argument(
-    '--epoch-size', type=int, default=100,
+    '-s', '--epoch-size', type=int, default=100,
     help='How many training samples to process between '
          'validation/preview/extended-stat calculation phases.'
+)
+parser.add_argument(
+    '-m', '--max-steps', type=int, default=500000,
+    help='Maximum number of training steps to perform.'
 )
 args = parser.parse_args()
 
@@ -54,7 +58,7 @@ target_h5data = [
     for i in range(3)
 ]
 
-max_steps = 500000
+max_steps = args.max_steps
 lr = 0.0004
 lr_stepsize = 1000
 lr_dec = 0.995

--- a/examples/train_unet_neurodata.py
+++ b/examples/train_unet_neurodata.py
@@ -7,7 +7,6 @@
 # Authors: Martin Drawitsch, Philipp Schubert
 
 import argparse
-import datetime
 import os
 
 import torch


### PR DESCRIPTION
There are a few breaking changes in this PR. Please refer to the updated scripts in the `examples` directory and the updated docs for fixing old custom training scripts if needed.

Highlights:
- `Trainer` (a.k.a. `StoppableTrainer`) and `PatchCreator` are now cleanly separated and can both be used independently. Therefore, using `Trainer` with a custom `Dataset` or using `PatchCreator` with a custom training loop should be straightforward now.
- `PatchCreator`'s interface is now much closer to `torchvision.datasets`, which are the PyTorch standard for `torch.utils.data.Dataset` implementations.
- `Trainer` now fully supports both 3D and 2D segmentation workflows. Data shapes don't have to be specified, they are handled automatically.
- Tensorboard plotting in `Trainer` now works transparently for 3D and 2D images.
- A toy 2D segmentation dataset (`SimpleNeuroData2d`) that treats the depth dimension D of a HDF5 array as the index and delivers (H, W) slices. It doesn't yet support any augmentations and only contains 150 images, so don't expect impressive results from it. However, it can be used as a proof of concept for testing 2D segmentation workflows. `SimpleNeuroData2d` doesn't require any extra files except the standard `neuro_data_cdhw` dataset being located in `~/neuro_data_cdhw`, where all other examples expect it as well (speaking about defaults. The path is configurable of course). Augmentations are planned to be supported soon via the standard `torchvision.transforms` interface.
- A simple demo training script that shows a 2D segmentation workflow (`examples/simple2d.py`). It uses the aforementioned toy dataset and a really simple Convnet architecture that is just there as a placeholder until serious 2D network architectures are available.

Partially addressing #5.