### PR TITLE
New transforms API for datasets

### DIFF
--- a/elektronn3/data/cnndata.py
+++ b/elektronn3/data/cnndata.py
@@ -21,8 +21,6 @@ from torch.utils import data
 
 from elektronn3.data import transformations, transforms  # TODO: Rename transformations module
 from elektronn3.data.utils import slice_h5
-from elektronn3.data.random_blurring import check_random_data_blurring_config
-from elektronn3.data.random_blurring import apply_random_blurring
 
 logger = logging.getLogger('elektronn3log')
 
@@ -212,9 +210,6 @@ class PatchCreator(data.Dataset):
 
         self.load_data()  # Open dataset files
 
-        self._mean = None
-        self._std = None
-
         if transform is None:
             transform = lambda x: x
         self.transform = transform
@@ -309,42 +304,6 @@ class PatchCreator(data.Dataset):
         s = s.format(self.c_target, self.c_input, self._training_count,
                      self._valid_count, self.n_labelled_pixels)
         return s
-
-    # TODO: Support individual per-cube mean/std (in case of high differences
-    #       between cubes)? Not sure if this is important.
-
-    # TODO: Respect separate channels
-    @property
-    def mean(self) -> float:
-        if self._mean is None:
-            logger.warning(
-                'Calculating mean of training inputs. This is potentially slow. Please supply\n'
-                'it manually when initializing the data set to make startup faster.'
-            )
-            means = [np.mean(x) for x in self.inputs]
-            self._mean = np.mean(means)
-            logger.info(f'mean = {self._mean:.6f}')
-        return self._mean
-
-    # TODO: Respect separate channels
-    @property
-    def std(self) -> float:
-        if self._std is None:
-            logger.warning(
-                'Calculating std of training inputs. This is potentially slow. Please supply\n'
-                'it manually when initializing the data set to make startup faster.'
-            )
-            stds = [np.std(x) for x in self.inputs]
-            # Note that this is not the same as the std of all train_inputs
-            # together. The mean of stds of the individual input data cubes
-            # is different because it only acknowledges intra-cube variance,
-            # not variance between training cubes.
-            # TODO: Does it make sense to have the actual global std of all
-            #       training inputs? If yes, how can it be computed without
-            #       loading everything into RAM at once?
-            self._std = np.mean(stds)
-            logger.info(f'std = {self._std:.6f}')
-        return self._std
 
     def _create_preview_batch(
             self,

--- a/elektronn3/data/cnndata.py
+++ b/elektronn3/data/cnndata.py
@@ -19,7 +19,7 @@ import numpy as np
 import torch
 from torch.utils import data
 
-from elektronn3.data import transformations, transforms  # TODO: Rename transformations module
+from elektronn3.data import coord_transforms, transforms
 from elektronn3.data.utils import slice_h5
 
 logger = logging.getLogger('elektronn3log')
@@ -100,7 +100,7 @@ class PatchCreator(data.Dataset):
         warp: ratio of training samples that should be obtained using
             geometric warping augmentations.
         warp_kwargs: kwargs that are passed through to
-            :py:meth:`elektronn3.data.transformations.get_warped_slice()`.
+            :py:meth:`elektronn3.data.coord_transforms.get_warped_slice()`.
             See the docs of this function for information on kwargs options.
             Can be empty.
         epoch_size: Determines the length (``__len__``) of the ``Dataset``
@@ -255,7 +255,7 @@ class PatchCreator(data.Dataset):
                     # TODO: Find out where to catch this early / prevent this issue from happening
                     logger.warning(f'invalid target: max = {target.max()}. Skipping batch...')
                     continue
-            except transformations.WarpingOOBError:
+            except coord_transforms.WarpingOOBError:
                 self.n_failed_warp += 1
                 if self.n_failed_warp > 20 and self.n_failed_warp > 2 * self.n_successful_warp:
                     fail_ratio = self.n_failed_warp / (self.n_failed_warp + self.n_successful_warp)
@@ -401,7 +401,7 @@ class PatchCreator(data.Dataset):
             warp_kwargs: Dict[str, Any]
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
-        (Wraps :py:meth:`elektronn3.data.transformations.get_warped_slice()`)
+        (Wraps :py:meth:`elektronn3.data.coord_transforms.get_warped_slice()`)
 
         Cuts a warped slice out of the input and target arrays.
         The same random warping transformation is each applied to both input
@@ -424,7 +424,7 @@ class PatchCreator(data.Dataset):
             applies warping to the image-target pair.
         warp_kwargs: dict
             kwargs that are passed through to
-            :py:meth:`elektronn2.data.transformations.get_warped_slice()`.
+            :py:meth:`elektronn2.data.coord_transforms.get_warped_slice()`.
             Can be empty.
 
         Returns
@@ -445,7 +445,7 @@ class PatchCreator(data.Dataset):
             warp_kwargs = dict(warp_kwargs)
             warp_kwargs['warp_amount'] = 0
 
-        inp, target = transformations.get_warped_slice(
+        inp, target = coord_transforms.get_warped_slice(
             inp_src,
             self.patch_shape,
             aniso_factor=self.aniso_factor,

--- a/elektronn3/data/cnndata.py
+++ b/elektronn3/data/cnndata.py
@@ -122,8 +122,9 @@ class PatchCreator(data.Dataset):
             To combine multiple transforms, use
             :py:class:`elektronn3.data.transforms.Compose`.
             See :py:mod:`elektronn3.data.transforms`. for some implementations.
-
-
+        num_classes: The total number of different target classes that exist
+            in the data set. Setting this is optional, but some features might
+            only work if this is specified.
     """
     def __init__(
             self,
@@ -140,6 +141,7 @@ class PatchCreator(data.Dataset):
             epoch_size: int = 100,
             squeeze_target: bool = False,
             transform: Callable = transforms.Identity(),
+            num_classes: Optional[int] = None
     ):
         # Early checks
         if len(input_h5data) != len(target_h5data):
@@ -177,6 +179,7 @@ class PatchCreator(data.Dataset):
         self.target_discrete_ix = target_discrete_ix
         self.epoch_size = epoch_size
         self._orig_epoch_size = epoch_size  # Store original epoch_size so it can be reset later.
+        self.num_classes = num_classes
 
         self.patch_shape = np.array(patch_shape, dtype=np.int)
         self.ndim = self.patch_shape.ndim

--- a/elektronn3/data/cnndata.py
+++ b/elektronn3/data/cnndata.py
@@ -115,6 +115,15 @@ class PatchCreator(data.Dataset):
             channel axis if it is empty. This workaround and will be removed
             later. It is currently needed to support targets that have an
             extra channel axis which doesn't exist in the network outputs.
+        transform: Transformation function to be applied to ``(inp, target)``
+            samples (for normalization, data augmentation etc.). The signature
+            is always ``inp, target = transform(inp, target)``, where ``inp``
+            and ``target`` both are ``numpy.ndarray``s.
+            To combine multiple transforms, use
+            :py:class:`elektronn3.data.transforms.Compose`.
+            See :py:mod:`elektronn3.data.transforms`. for some implementations.
+
+
     """
     def __init__(
             self,

--- a/elektronn3/data/coord_transforms.py
+++ b/elektronn3/data/coord_transforms.py
@@ -15,8 +15,7 @@ from elektronn3 import floatX
 from elektronn3.data.utils import slice_h5
 
 # TODO: A major refactoring is required here:
-#  This module should be renamed to something like coord_transforms and
-#  it should not perform any data I/O itself. Instead it should provide a
+#  This module should not perform any data I/O itself. Instead it should provide a
 #  framework for generating and transforming source coordinates (with
 #  support for user-defined transforms, similar to the image transforms pipeline).
 #  Code for HDF5 slicing and voxel value interpolation should be in separate modules.
@@ -390,7 +389,7 @@ def get_warped_slice(inp_src, ps, aniso_factor=2, sample_aniso=True,
                      target_src=None, target_ps=None,
                      target_discrete_ix=None, rng=None):
     """
-    (Wraps :py:meth:`elektronn2.data.transformations.warp_slice()`)
+    (Wraps :py:meth:`elektronn2.data.coord_transforms.warp_slice()`)
 
     Generates the warping transformation parameters and composes them into a
     single 4D homogeneous transformation matrix ``M``.

--- a/elektronn3/data/coord_transforms.py
+++ b/elektronn3/data/coord_transforms.py
@@ -21,32 +21,6 @@ from elektronn3.data.utils import slice_h5
 #  Code for HDF5 slicing and voxel value interpolation should be in separate modules.
 
 
-# TODO: Revise this. Especially the clipping is very destructive!
-# This is currently broken because it expects floats in the range (0, 1)
-# and we can't supply those (except by re-breaking normalization or awkward
-# and lossy transforms before and after calling this function).
-def grey_augment(d, channels, rng):
-    """
-    Performs grey value (histogram) augmentations on ``d``. This is only
-    applied to ``channels`` (list of channels indices), ``rng`` is a random
-    number generator
-    """
-    raise NotImplementedError
-    if channels == []:
-        return d
-    else:
-        k = len(channels)
-        d = d.copy()  # d is still just a view, we don't want to change the original data so copy it
-        alpha = 1 + (rng.rand(k) - 0.5) * 0.3 # ~ contrast
-        c     = (rng.rand(k) - 0.5) * 0.3 # mediates whether values are clipped for shadows or lights
-        gamma = 2.0 ** (rng.rand(k) * 2 - 1) # sample from [0.5,2] with mean 0
-
-        d[channels] = d[channels] * alpha[:,None,None] + c[:,None,None]
-        d[channels] = np.clip(d[channels], 0, 1)
-        d[channels] = d[channels] ** gamma[:,None,None]
-    return d
-
-
 @numba.guvectorize(['void(float32[:,:,:], float32[:], float32[:], float32[:,],)'],
               '(x,y,z),(i),(i)->()', nopython=True)#target='parallel',
 def map_coordinates_nearest(src, coords, lo, dest):

--- a/elektronn3/data/random_blurring.py
+++ b/elektronn3/data/random_blurring.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2017 - now
 # Max Planck Institute of Neurobiology, Munich, Germany
-# Authors: Martin Drawitsch, Philipp Schubert, Marius Killinger
+# Authors: Ravil Dorozhinskii, Martin Drawitsch
 
 import numpy as np
 from itertools import product

--- a/elektronn3/data/region_generator.py
+++ b/elektronn3/data/region_generator.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2017 - now
 # Max Planck Institute of Neurobiology, Munich, Germany
-# Authors: Martin Drawitsch, Philipp Schubert, Marius Killinger
+# Authors: Ravil Dorozhinskii
 
 import numpy as np
 

--- a/elektronn3/data/transformations.py
+++ b/elektronn3/data/transformations.py
@@ -14,6 +14,13 @@ import numba
 from elektronn3 import floatX
 from elektronn3.data.utils import slice_h5
 
+# TODO: A major refactoring is required here:
+#  This module should be renamed to something like coord_transforms and
+#  it should not perform any data I/O itself. Instead it should provide a
+#  framework for generating and transforming source coordinates (with
+#  support for user-defined transforms, similar to the image transforms pipeline).
+#  Code for HDF5 slicing and voxel value interpolation should be in separate modules.
+
 
 # TODO: Revise this. Especially the clipping is very destructive!
 # This is currently broken because it expects floats in the range (0, 1)

--- a/elektronn3/data/transforms.py
+++ b/elektronn3/data/transforms.py
@@ -99,7 +99,7 @@ class RandomBlurring:  # Warning: This operates in-place!
 
 
 class RandomCrop:
-    def __init__(self, size: Union[int, Sequence[int]]):
+    def __init__(self, size: Sequence[int]):
         self.size = np.array(size)
 
     def __call__(
@@ -128,5 +128,8 @@ class RandomCrop:
         inp_cropped = inp[full_slice]
         if target is None:
             return inp_cropped, target
+
+        if target.ndim == inp.ndim - 1:  # inp: (C, [D,], H, W), target: ([D,], H, W)
+            full_slice = full_slice[1:]  # Remove C axis from slice because target doesn't have it
         target_cropped = target[full_slice]
         return inp_cropped, target_cropped

--- a/elektronn3/data/transforms.py
+++ b/elektronn3/data/transforms.py
@@ -16,9 +16,11 @@ Important note: The transformations here have a similar interface to
     torch.Tensor data.
 """
 
-from typing import Sequence, Tuple, Optional
+from typing import Sequence, Tuple, Optional, Dict, Any
 
 import numpy as np
+
+from elektronn3.data.random_blurring import apply_random_blurring, check_random_data_blurring_config
 
 
 # Transformation = Callable[[np.ndarray, np.ndarray], Tuple[np.ndarray, np.ndarray]]
@@ -73,3 +75,23 @@ class Normalize:
         for c in range(inp.shape[0]):
             normalized[c] = (inp[c] - self.mean[c]) / self.std[c]
         return normalized, target
+
+
+class RandomBlurring:  # Warning: This operates in-place!
+    def __init__(
+            self,
+            config: Dict[str, Any],
+            patch_shape: Optional[Sequence[int]] = None
+    ):
+        self.config = config
+        if patch_shape is not None:
+            check_random_data_blurring_config(patch_shape, **config)
+
+    def __call__(
+            self,
+            inp: np.ndarray,
+            target: Optional[np.ndarray]  # returned without modifications
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        # In-place, overwrites inp!
+        apply_random_blurring(inp_sample=inp, **self.config)
+        return inp, target

--- a/elektronn3/data/transforms.py
+++ b/elektronn3/data/transforms.py
@@ -1,0 +1,75 @@
+# ELEKTRONN3 - Neural Network Toolkit
+#
+# Copyright (c) 2017 - now
+# Max Planck Institute of Neurobiology, Munich, Germany
+# Authors: Martin Drawitsch
+
+"""
+Transformations (data augmentation, normalization etc.) for semantic segmantation.
+
+Important note: The transformations here have a similar interface to
+ torchvsion.transforms, but there are two key differences:
+ 1. They all map (inp, target) pairs to (transformed_inp, transformed_target)
+    pairs instead of just inp to inp.
+    Most transforms don't change the target, though.
+ 2. They exclusively operate on numpy.ndarray data instead of PIL or
+    torch.Tensor data.
+"""
+
+from typing import Sequence, Tuple, Optional
+
+import numpy as np
+
+
+# Transformation = Callable[[np.ndarray, np.ndarray], Tuple[np.ndarray, np.ndarray]]
+
+
+class Identity:
+    def __call__(self, inp, target):
+        return inp, target
+
+
+class Compose:
+    """Composes several transforms together.
+    Args:
+        transforms (list of ``Transform`` objects): list of transforms to compose.
+    Example:
+        >>> Compose([
+        >>>     Normalize(mean=(155.291411,), std=(41.812504,)),
+        >>> ])
+    """
+
+    def __init__(self, transforms):
+        self.transforms = transforms
+
+    def __call__(self, inp, target):
+        for t in self.transforms:
+            inp, target = t(inp, target)
+        return inp, target
+
+    def __repr__(self):
+        format_string = self.__class__.__name__ + '('
+        for t in self.transforms:
+            format_string += '\n    {0}'.format(t)
+        format_string += '\n)'
+        return format_string
+
+
+class Normalize:
+    """Normalizes inputs with supplied per-channel means and stds."""
+    def __init__(self, mean: Sequence[float], std: Sequence[float]):
+        self.mean = np.array(mean)
+        self.std = np.array(std)
+
+    def __call__(
+            self,
+            inp: np.ndarray,
+            target: Optional[np.ndarray]  # returned without modifications
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        normalized = np.empty_like(inp)
+        if not inp.shape[0] == self.mean.shape[0] == self.std.shape[0]:
+            raise ValueError('mean and std must have the same length as the C '
+                             'axis (number of channels) of the input.')
+        for c in range(inp.shape[0]):
+            normalized[c] = (inp[c] - self.mean[c]) / self.std[c]
+        return normalized, target

--- a/elektronn3/data/utils.py
+++ b/elektronn3/data/utils.py
@@ -19,6 +19,27 @@ from elektronn3 import floatX
 logger = logging.getLogger("elektronn3log")
 
 
+# TODO: Respect separate channels
+def calculate_mean(inputs: Sequence) -> Sequence[float]:
+    means = [np.mean(x) for x in inputs]
+    mean = np.mean(means)
+    return mean
+
+
+# TODO: Respect separate channels
+def calculate_std(inputs: Sequence) -> Sequence[float]:
+    stds = [np.std(x) for x in inputs]
+    # Note that this is not the same as the std of all inputs
+    # together. The mean of stds of the individual input data cubes
+    # is different because it only acknowledges intra-cube variance,
+    # not variance between training cubes.
+    # TODO: Does it make sense to have the actual global std of all
+    #       training inputs? If yes, how can it be computed without
+    #       loading everything into RAM at once?
+    std = np.mean(stds)
+    return std
+
+
 def calculate_class_weights(
         targets: Sequence[np.ndarray],
         mode='binmean'

--- a/elektronn3/data/utils.py
+++ b/elektronn3/data/utils.py
@@ -33,30 +33,21 @@ def _to_full_numpy(seq):
 
 
 def calculate_means(inputs: Sequence) -> Tuple[float]:
-    inputs = _to_full_numpy(inputs)
-    means = []  # Per-channel mean values
-    num_channels = inputs[0].shape[0]
-    for c in range(num_channels):
-        seq_means = [x[c].mean() for x in inputs]  # Per array mean for channel c
-        mean = np.mean(seq_means)  # Total mean of channel c in all arrays
-        means.append(float(mean))
+    # TODO: This implementation can surely be optimized (esp. memory usage)
+    inputs = _to_full_numpy(inputs)  # (N, C, D, H, W)
+    channelfirst = inputs.swapaxes(0, 1)  # (C, N, D, H, W)
+    flat = channelfirst.reshape(channelfirst.shape[0], -1)  # (C, N*D*H*W)
+    means = flat.mean(axis=1)  # For each channel, calculate mean of all values
     return tuple(means)
 
 
 # TODO: Respect separate channels
 def calculate_stds(inputs: Sequence) -> Tuple[float]:
+    # TODO: This implementation can surely be optimized (esp. memory usage)
     inputs = _to_full_numpy(inputs)
-    stds = []  # Per-channel std values
-    num_channels = inputs[0].shape[0]
-    for c in range(num_channels):
-        seq_stds = [np.std(x) for x in inputs]
-        # Note that this is not the same as the std of all inputs
-        # together. The mean of stds of the individual input data cubes
-        # is different because it only acknowledges intra-cube variance,
-        # not variance between training cubes.
-        # TODO: Does it make sense to have the actual global std of all inputs?
-        std = np.mean(seq_stds)
-        stds.append(float(std))
+    channelfirst = inputs.swapaxes(0, 1)  # (C, N, D, H, W)
+    flat = channelfirst.reshape(channelfirst.shape[0], -1)  # (C, N*D*H*W)
+    stds = flat.std(axis=1)  # For each channel, calculate std of all values
     return tuple(stds)
 
 

--- a/elektronn3/models/_model_utils.py
+++ b/elektronn3/models/_model_utils.py
@@ -1,0 +1,49 @@
+# ELEKTRONN3 - Neural Network Toolkit
+#
+# Copyright (c) 2017 - now
+# Max Planck Institute of Neurobiology, Munich, Germany
+# Authors: Martin Drawitsch
+
+"""Utilities for neural network model manipulation"""
+
+from typing import Tuple
+
+import torch
+from torch import nn
+
+
+def find_first(model: nn.Module, module_type: type = nn.Conv2d) -> Tuple[str, nn.Module]:
+    """Return the first submodule of an nn.Module with a certain type."""
+    for name, mod in model.named_modules():
+        if isinstance(mod, module_type):
+            return name, mod
+    # Loop finished, nothing found...
+    raise LookupError(f'Module does\'nt have any layers of type {module_type}.')
+
+
+def find_first_conv(model: nn.Module, in_channels=3) -> Tuple[str, nn.Module]:
+    """Return the first Conv2d submodule with a certain in_channels value."""
+    for name, mod in model.named_modules():
+        if isinstance(mod, nn.Conv2d) and mod.in_channels == in_channels:
+            return name, mod
+    # Loop finished, nothing found...
+    raise LookupError(f'Module does\'nt have any Conv2d layers with in_channels={in_channels}.')
+
+
+# TODO: Layer initialization?
+# TODO: Is it possible to re-use original conv1 weights in some way?
+def change_conv1_input_channels(
+        model: nn.Module,
+        old_in_channels: int = 3,
+        new_in_channels: int = 1
+) -> None:
+    """Change input channels of a convnet model (in-place).
+
+    This can be used to turn RGB models (``in_channels=3``) into single-channel
+    models (``in_channels=1``) automatically by replacing the first Conv layer,
+    while preserving pretrained weights in all other layers.."""
+    name, conv1 = find_first_conv(model, in_channels=old_in_channels)
+    model.__dict__[name] = nn.Conv2d(
+        new_in_channels, conv1.out_channels, conv1.kernel_size,
+        conv1.stride, conv1.padding, conv1.dilation, conv1.groups, conv1.bias
+    )

--- a/elektronn3/training/trainer.py
+++ b/elektronn3/training/trainer.py
@@ -111,6 +111,14 @@ class Trainer:
             C-level segfaults etc.) won't crash the whole training process,
             but drop to an IPython shell so errors can be inspected with
             access to the current training state.
+        num_classes: Optionally specifies the number of different target
+            classes for classification tasks. If this is not set manually,
+            the ``Trainer`` checks if the ``train_dataset`` provides this
+            value. If available, ``self.num_classes`` is set to
+            ``self.train_dataset.num_classes``. Otherwise, it is set to
+            ``None``.
+            The num_classes attribute is used for plotting purposes and is
+            not strictly required for training.
     """
     # TODO: Write logs of the text logger to a file in save_root. The file
     #       handler should be replaced (see elektronn3.logger module).
@@ -124,6 +132,7 @@ class Trainer:
     valid_loader: torch.utils.data.DataLoader
     exp_name: str
     save_path: str  # Full path to where training files are stored
+    num_classes: Optional[int]  # Number of different target classes in the train_dataset
 
     def __init__(
             self,
@@ -137,12 +146,13 @@ class Trainer:
             exp_name: Optional[str] = None,
             batchsize: int = 1,
             num_workers: int = 0,
-            schedulers: Optional[Dict[Any, Any]] = None,  # TODO: Define a Scheduler protocol. This needs typing_extensions.
+            schedulers: Optional[Dict[Any, Any]] = None,
             overlay_alpha: float = 0.2,
             enable_tensorboard: bool = True,
             tensorboard_root_path: Optional[str] = None,
             ignore_errors: bool = False,
-            ipython_on_error: bool = False
+            ipython_on_error: bool = False,
+            num_classes: Optional[int] = None,
     ):
         self.ignore_errors = ignore_errors
         self.ipython_on_error = ipython_on_error
@@ -178,6 +188,10 @@ class Trainer:
             schedulers = {'lr': StepLR(optimizer, 1000, 1)}  # No-op scheduler
         self.schedulers = schedulers
 
+        # Determine optional dataset properties
+        self.num_classes = None
+        if hasattr(self.train_dataset, 'num_classes'):
+            self.num_classes = self.train_dataset.num_classes
         self.previews_enabled = hasattr(valid_dataset, 'preview_batch')\
             and valid_dataset.preview_shape is not None
 

--- a/examples/random_blurring_augmentation_example.py
+++ b/examples/random_blurring_augmentation_example.py
@@ -4,7 +4,9 @@
 #
 # Copyright (c) 2017 - now
 # Max Planck Institute of Neurobiology, Munich, Germany
-# Authors: Martin Drawitsch, Philipp Schubert
+# Authors: Martin Drawitsch, Ravil Dorozhinskii
+
+# TODO: Sync
 
 import argparse
 import os

--- a/examples/simple2d.py
+++ b/examples/simple2d.py
@@ -77,7 +77,9 @@ dataset_std = (44.264744,)
 common_transforms = [
     transforms.Normalize(mean=dataset_mean, std=dataset_std)
 ]
-train_transform = transforms.Compose(common_transforms + [])
+train_transform = transforms.Compose(common_transforms + [
+    transforms.RandomCrop((128, 128))  # Use smaller patches for training
+])
 valid_transform = transforms.Compose(common_transforms + [])
 
 # Specify data set

--- a/examples/simple2d.py
+++ b/examples/simple2d.py
@@ -46,7 +46,7 @@ import elektronn3
 elektronn3.select_mpl_backend('Agg')
 
 from elektronn3.training import Trainer, Backup
-from elektronn3.data import SimpleNeuroData2d
+from elektronn3.data import SimpleNeuroData2d, transforms
 
 torch.manual_seed(0)
 
@@ -70,9 +70,19 @@ model = nn.Sequential(
 if args.resume is not None:  # Load pretrained network params
     model.load_state_dict(torch.load(os.path.expanduser(args.resume)))
 
+dataset_mean = (143.97594,)
+dataset_std = (44.264744,)
+
+# Transformations to be applied to samples before feeding them to the network
+common_transforms = [
+    transforms.Normalize(mean=dataset_mean, std=dataset_std)
+]
+train_transform = transforms.Compose(common_transforms + [])
+valid_transform = transforms.Compose(common_transforms + [])
+
 # Specify data set
-train_dataset = SimpleNeuroData2d(train=True)
-valid_dataset = SimpleNeuroData2d(train=False)
+train_dataset = SimpleNeuroData2d(train=True, transform=train_transform, num_classes=2)
+valid_dataset = SimpleNeuroData2d(train=False, transform=valid_transform, num_classes=2)
 
 # Set up optimization
 optimizer = optim.Adam(

--- a/examples/train_unet_neurodata.py
+++ b/examples/train_unet_neurodata.py
@@ -42,8 +42,7 @@ print(f'Running on device: {device}')
 import elektronn3
 elektronn3.select_mpl_backend('Agg')
 
-from elektronn3.data import PatchCreator
-from elektronn3.data import transforms
+from elektronn3.data import PatchCreator, transforms
 from elektronn3.training import Trainer, Backup, DiceLoss
 from elektronn3.models.unet import UNet
 

--- a/examples/train_unet_neurodata.py
+++ b/examples/train_unet_neurodata.py
@@ -96,6 +96,7 @@ common_data_kwargs = {  # Common options for training and valid sets.
     'aniso_factor': 2,
     'patch_shape': (48, 96, 96),
     'squeeze_target': True,  # Workaround for neuro_data_cdhw,
+    'num_classes': 2,
 }
 train_dataset = PatchCreator(
     input_h5data=input_h5data[:2],

--- a/examples/train_unet_neurodata.py
+++ b/examples/train_unet_neurodata.py
@@ -81,8 +81,8 @@ if args.resume is not None:  # Load pretrained network params
 
 # These statistics are computed from the training dataset.
 # Remember to re-compute and change them when switching the dataset.
-dataset_mean = (155.291411,)
-dataset_std = (41.812504,)
+dataset_mean = (155.291411,)  # = elektronn3.data.utils.calculate_means(train_dataset.inputs)
+dataset_std = (42.599973,)  # = elektronn3.data.utils.calculate_stds(train_dataset.inputs)
 
 # Transformations to be applied to samples before feeding them to the network
 common_transforms = [

--- a/examples/train_unet_neurodata.py
+++ b/examples/train_unet_neurodata.py
@@ -42,7 +42,7 @@ print(f'Running on device: {device}')
 import elektronn3
 elektronn3.select_mpl_backend('Agg')
 
-from elektronn3.data import PatchCreator, transforms, calculate_class_weights
+from elektronn3.data import PatchCreator, transforms, utils
 from elektronn3.training import Trainer, Backup, DiceLoss, LovaszLoss
 from elektronn3.models.unet import UNet
 
@@ -81,8 +81,8 @@ if args.resume is not None:  # Load pretrained network params
 
 # These statistics are computed from the training dataset.
 # Remember to re-compute and change them when switching the dataset.
-dataset_mean = (155.291411,)  # = elektronn3.data.utils.calculate_means(train_dataset.inputs)
-dataset_std = (42.599973,)  # = elektronn3.data.utils.calculate_stds(train_dataset.inputs)
+dataset_mean = (155.291411,)
+dataset_std = (42.599973,)
 
 # Transformations to be applied to samples before feeding them to the network
 common_transforms = [
@@ -135,8 +135,8 @@ optimizer = optim.Adam(
 lr_sched = optim.lr_scheduler.StepLR(optimizer, lr_stepsize, lr_dec)
 # lr_sched = optim.lr_scheduler.ReduceLROnPlateau(optimizer, patience=10, factor=0.5)
 
-# Get class weights for imbalanced datasets
-class_weights = torch.tensor(calculate_class_weights(train_dataset.targets))
+# Class weights for imbalanced dataset
+class_weights = torch.tensor([0.2653,  0.7347])
 
 criterion = nn.CrossEntropyLoss(weight=class_weights)
 # criterion = DiceLoss()
@@ -162,3 +162,9 @@ Backup(script_path=__file__,save_path=trainer.save_path).archive_backup()
 
 # Start training
 trainer.train(max_steps)
+
+
+# How to re-calculate mean, std and class_weights for other datasets:
+#  dataset_mean = utils.calculate_means(train_dataset.inputs)
+#  dataset_std = utils.calculate_stds(train_dataset.inputs)
+#  class_weights = torch.tensor(utils.calculate_class_weights(train_dataset.targets))


### PR DESCRIPTION
The new `transforms` module contains "non-geometric" augmentations and provides a normalization helper. The general idea of this is very similar to the idea of `torchvision.transforms`, but based on NumPy and with additional support for joint input-target transforms (see the commit message of 8a89d46 for further details and discussion about API design).
Now it should be very easy to implement new augmentation methods inside and outside of elektronn3.
"Geometric" transforms (source coordinate transformations) will be worked on in the next weeks.

This is an important step for #2.