### PR TITLE
correct metrics with ignore class

### DIFF
--- a/elektronn3/training/metrics.py
+++ b/elektronn3/training/metrics.py
@@ -90,12 +90,13 @@ def confusion_matrix(
         pos_pred = pred == c
         neg_pred = ~pos_pred
         pos_target = target == c
+        ign_target = target == num_classes - 1
         neg_target = ~pos_target
 
-        true_pos = (pos_pred & pos_target).sum(dtype=dtype)
-        true_neg = (neg_pred & neg_target).sum(dtype=dtype)
-        false_pos = (pos_pred & neg_target).sum(dtype=dtype)
-        false_neg = (neg_pred & pos_target).sum(dtype=dtype)
+        true_pos = (pos_pred & pos_target & ~ign_target).sum(dtype=dtype)
+        true_neg = (neg_pred & neg_target & ~ign_target).sum(dtype=dtype)
+        false_pos = (pos_pred & neg_target & ~ign_target).sum(dtype=dtype)
+        false_neg = (neg_pred & pos_target & ~ign_target).sum(dtype=dtype)
 
         cm[c] = torch.tensor([true_pos, true_neg, false_pos, false_neg])
 


### PR DESCRIPTION
just as inspiration
this is obviously not ok as default
the ignore class id(s) should somehow end up in that function but e3 currently doesn’t know about them (the class_weights) at all